### PR TITLE
transaction -> fn-tx usage of pop from contract function args

### DIFF
--- a/src/cloth/tx.cljc
+++ b/src/cloth/tx.cljc
@@ -158,7 +158,7 @@
 (defn fn-tx
   ([contract fn-abi args]
    (let [params (if (map? (last args)) (last args) {})
-         args (if (map? (last args)) (pop args) args)
+         args (if (map? (last args)) (rest args) args)
          types (map :type (:inputs fn-abi))]
      (fn-tx contract (:name fn-abi) types args params)))
   ([contract name types args params]


### PR DESCRIPTION
ArraySeq does not implement clojure.lang.IPersistentStack.

moved to rest for lazyseq 