### PR TITLE
json-rpc-response  should throw on error

### DIFF
--- a/src/cloth/net.cljc
+++ b/src/cloth/net.cljc
@@ -31,7 +31,7 @@
 (defn json-rpc-response [response]
   ;(prn (:body response))
   (if-let [error (get-in response [:body :error])]
-    (ex-info "json-rpc-error" error)
+    (throw (ex-info "json-rpc-error" error))
     (get-in response [:body :result])))
 
 (defn process-response

--- a/src/cloth/tx.cljc
+++ b/src/cloth/tx.cljc
@@ -158,7 +158,7 @@
 (defn fn-tx
   ([contract fn-abi args]
    (let [params (if (map? (last args)) (last args) {})
-         args (if (map? (last args)) (pop args) args)
+         args (if (map? (last args)) (rest args) args)
          types (map :type (:inputs fn-abi))]
      (fn-tx contract (:name fn-abi) types args params)))
   ([contract name types args params]


### PR DESCRIPTION
downstream promise need correct results or parse; like when a contract wants to know when a tx has been mined which uses the tx hash. If that does not occur we should catch at top level and deal with the badness there.