### PR TITLE
Fixed function generation 

### DIFF
--- a/src/cloth/contracts.cljc
+++ b/src/cloth/contracts.cljc
@@ -85,7 +85,7 @@
      "
      [contract file]
      (let [compiled (compile-solidity file)
-           contract-key (keyword (c/capitalize (c/camel (name contract))))
+           contract-key (keyword (str file ":" (c/capitalize (c/camel (name contract)))))
            binary (get-in compiled [:contracts contract-key :bin])
            abi (json/parse-string (get-in compiled [:contracts contract-key :abi]) true)
            functions (filter #(= (:type %) "function") abi)


### PR DESCRIPTION
`solc` prefixes the file path to the contract name (ie "path/to/contract.sol:contract")

Cloth was not following this format, so the functions were not created.

I'm an using solc version `0.4.11`.