### PR TITLE
Upgrade for solc 0.4.16 and TestRPC v4.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ The `cloth.contracts` namespace allows you to compile solidity code and create c
 
 (defcontract simple-token "test/cloth/SimpleToken.sol")
 
+;; The contract name argument must be the skewer-case version of the Solidity contract name.
+;; In the example above, the use of `simple-token` means there's a contract named `SimpleToken` in SimpleToken.sol file.
+;; Any solc compiler warnings are treated as an error; an optional `ignore-warnings?` argument to `defcontract` over-rides the default behavior.
+
 ;; For simplicity sake the rest of the examples use Clojure @ syntax for dereferencing Promises
 
 ;; Deploy the solidity code to the blockchain
@@ -198,6 +202,8 @@ testrpc -b 1
 ### Clojure tests
 
 Run `lein test` or `lein test-refresh`.
+
+Tests assume gasPrice is 1, so use `testrpc -g 1 -b 1`
 
 ### Clojurescript tests
 

--- a/test/cloth/Constructed.sol
+++ b/test/cloth/Constructed.sol
@@ -1,4 +1,5 @@
-pragma solidity ^0.4.1;
+pragma solidity ^0.4.16;
+
 contract Constructed {
     string public status;
 

--- a/test/cloth/SimpleToken.sol
+++ b/test/cloth/SimpleToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.1;
+pragma solidity ^0.4.16;
 contract SimpleToken {
   uint32 public circulation;
   address public issuer;
@@ -9,7 +9,7 @@ contract SimpleToken {
   bytes32 public ipfs;
 
   event Issued(address indexed recipient, uint32 amount);
-  event Message(address indexed shouter, string message);
+  event Message(address indexed shouter, string _message);
   event Transferred(address indexed sender, address indexed recipient, uint32 amount);
 
   function SimpleToken() {
@@ -21,17 +21,17 @@ contract SimpleToken {
   modifier authorizedCustomer(address customer) { if (authorized[customer] != 0 ) _ ; }
   modifier unAuthorizedCustomer(address customer) { if (authorized[customer] == 0 ) _ ; }
 
-  function customer(address customer) constant
+  function customer(address _customer) constant
     returns(uint authorizedTime, uint32 balance) {
-    return (authorized[customer], balances[customer]);
+    return (authorized[_customer], balances[_customer]);
   }
 
-  function authorize(address customer) public
+  function authorize(address _customer) public
     onlyIssuer
-    unAuthorizedCustomer(customer)
+    unAuthorizedCustomer(_customer)
     returns(bool success) {
-        authorized[customer] = block.timestamp;
-        customers.push(customer);
+        authorized[_customer] = block.timestamp;
+        customers.push(_customer);
         return true;
   }
 
@@ -45,9 +45,9 @@ contract SimpleToken {
   }
 
   function setMessage(string _message)
-    public returns(string message) {
+    public returns(string) {
         message = _message;
-        Message(msg.sender,message);
+        Message(msg.sender,_message);
         return message;
   }
 

--- a/test/cloth/core_test.cljc
+++ b/test/cloth/core_test.cljc
@@ -158,7 +158,7 @@
 (deftest sign-with-signer-proxy-test
   (let [keypair (keys/create-keypair)]
     (reset! core/global-signer keypair)
-    (c/defcontract proxy "test/cloth/Proxy.sol")
+    (c/defcontract proxy "test/cloth/Proxy.sol" :ignore-compiler-warnings)
 
     (let [recipient (:address (keys/create-keypair))]
       #?(:cljs


### PR DESCRIPTION
* Solc
  * The format of the JSON emitted by solc changed between version 0.4.1
   and 0.4.16.  The keys for contracts used to be the contract name but
   now they include the file name.  Old: "SimpleToken", new: "path/to/SimpleToken:SimpleToken".
  * cloth.contracts/compile-solidity accepts the newer version of solc
   JSON output
  * The new version of compile-solidity accepts solc 0.4.1 output as well
   as 0.4.16 output.
  * There's an optional compile-solidity argument, `ignore-warnings?` that
   treats the compilation as successful when there are warnings but solc
   exit status is zero.  If solc returns a non-zero status,
   compile-solidity fails either way.
* TestRPC
  * The default `testrpc` gasPrice is very large (20000000000) which
   caused many test failures.  Some failed due to out-of-gas errors.
   Others failed because they explicitly tested for gasPrice of 1.
  * Starting TestRPC with `--gasPrice 1` allows the tests to pass.